### PR TITLE
[WQ-196] refactor: 화면 이동 조건부 렌더링에서 React Navigation으로 전환

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -115,6 +115,7 @@ function LoginMobileApp({
     switchToKakaoAuth,
     switchToNaverAuth,
     setNavigationRef,
+    onNavigationStateChange,
   } = useScreenNavigation({
     emailAuthManager,
     googleAuthManager,
@@ -177,6 +178,7 @@ function LoginMobileApp({
       }}
       initialRouteName="Splash"
       setNavigationRef={setNavigationRef}
+      onNavigationStateChange={onNavigationStateChange}
     />
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -26,15 +26,9 @@ import {
   AuthActions 
 } from './src';
 import { useAuthManagers } from './src/hooks/useAuthManagers';
-import { useScreenNavigation, ScreenType } from './src/hooks/useScreenNavigation';
-import { DashboardScreen } from './src/screens/DashboardScreen';
-import { LoginSelectorScreen } from './src/screens/LoginSelectorScreen';
-import { OAuthContinueScreen } from './src/screens/OAuthContinueScreen';
-import { SplashScreen } from './src/screens/SplashScreen';
-import { EmailInputScreen } from './src/screens/EmailInputScreen';
-import { VerificationCodeScreen } from './src/screens/VerificationCodeScreen';
-import { LoginCompleteScreen } from './src/screens/LoginCompleteScreen';
-import { ServiceMainScreen } from './src/screens/ServiceMainScreen';
+import { useScreenNavigation } from './src/hooks/useScreenNavigation';
+import { useAuthHandlers } from './src/hooks/useAuthHandlers';
+import { AppNavigator } from './src/navigation/AppNavigator';
 
 
 
@@ -105,7 +99,6 @@ function LoginMobileApp({
     currentAuthManager,
     currentProvider,
     emailForVerification,
-    setCurrentScreen,
     setEmailForVerification,
     handleStartApp,
     handleBackToSplash,
@@ -121,6 +114,7 @@ function LoginMobileApp({
     switchToGoogleAuth,
     switchToKakaoAuth,
     switchToNaverAuth,
+    setNavigationRef,
   } = useScreenNavigation({
     emailAuthManager,
     googleAuthManager,
@@ -136,205 +130,53 @@ function LoginMobileApp({
   console.log('[App] 현재 인증 상태:', authState);
   console.log('[App] 현재 화면:', currentScreen);
 
-  // 구글 로그인 핸들러 (계속하기 화면으로 이동)
-  const handleGoogleLogin = () => {
-    handleOAuthContinue('google');
-  };
+  // 인증 핸들러 훅 사용
+  const { handleOAuthLogin, handleLogout } = useAuthHandlers({
+    emailAuthManager,
+    googleAuthManager,
+    kakaoAuthManager,
+    naverAuthManager,
+    switchToGoogleAuth,
+    switchToKakaoAuth,
+    switchToNaverAuth,
+    clearError,
+    handleBackToSplash,
+    authActions,
+  });
 
-  // OAuth 계속하기에서 실제 로그인 시도
-  const handleOAuthLogin = async (provider: 'google' | 'kakao' | 'naver') => {
-    console.log(`[App] ${provider} 로그인 시작`);
-    
-    // 해당 AuthManager로 전환
-    if (provider === 'google') {
-      switchToGoogleAuth();
-    } else if (provider === 'kakao') {
-      switchToKakaoAuth();
-    } else if (provider === 'naver') {
-      switchToNaverAuth();
-    }
-    
-    clearError();
-    
-    try {
-      let oauthAuthActions;
-      if (provider === 'google') {
-        oauthAuthActions = new AuthActions(googleAuthManager);
-      } else if (provider === 'kakao') {
-        oauthAuthActions = new AuthActions(kakaoAuthManager);
-      } else {
-        oauthAuthActions = new AuthActions(naverAuthManager);
-      }
-      
-      const success = await oauthAuthActions.startOAuth(provider);
-      if (success) {
-        console.log(`[App] ${provider} 로그인 시작 성공`);
-      } else {
-        console.log(`[App] ${provider} 로그인 시작 실패`);
-      }
-    } catch (error) {
-      console.error(`[App] ${provider} 로그인 예외:`, error);
-    }
-  };
-
-  // 로그아웃 핸들러
-  const handleLogout = async () => {
-    console.log('[App] 로그아웃 시작');
-    
-    try {
-      const success = await authActions.signOut();
-      if (success) {
-        console.log('[App] 로그아웃 성공');
-        // 웹 앱과 동일하게 스플래시 화면으로 리다이렉트
-        handleBackToSplash();
-      } else {
-        console.log('[App] 로그아웃 실패');
-        // 실패해도 스플래시 화면으로 이동 (로컬 세션 정리)
-        handleBackToSplash();
-      }
-    } catch (error) {
-      console.error('[App] 로그아웃 예외:', error);
-      // 예외 발생해도 스플래시 화면으로 이동 (로컬 세션 정리)
-      handleBackToSplash();
-    }
-  };
-
-  // 스플래시 화면
-  if (currentScreen === 'splash') {
-    return <SplashScreen onStartApp={handleStartApp} />;
-  }
-
-  // 로그인 완료 화면
-  if (currentScreen === 'login-complete') {
-    return (
-      <LoginCompleteScreen
-        onConnectNow={handleConnectNow}
-        onLater={handleLater}
-      />
-    );
-  }
-
-  // 서비스 메인 화면
-  if (currentScreen === 'service-main') {
-    return (
-      <ServiceMainScreen
-        isAuthenticated={authState.isLoggedIn}
-        onGoToDashboard={handleGoToDashboard}
-        onLogout={handleLogout}
-        onGoToLogin={handleGoToLogin}
-        onBackToLoginComplete={handleBackToLoginComplete}
-      />
-    );
-  }
-
-  // 대시보드 화면
-  if (currentScreen === 'dashboard') {
-    return (
-      <DashboardScreen 
-        authState={authState}
-        currentProvider={currentProvider}
-        onLogout={handleLogout}
-        onBackToLoginComplete={handleBackToLoginComplete}
-      />
-    );
-  }
-
-  // 로그인된 상태 - 기본적으로 로그인 선택 화면 표시 (로그아웃 후 돌아올 곳)
-  if (authState.isLoggedIn && !['login-complete', 'service-main', 'dashboard'].includes(currentScreen)) {
-    return (
-      <DashboardScreen 
-        authState={authState}
-        currentProvider={currentProvider}
-        onLogout={handleLogout}
-        onBackToLoginComplete={handleBackToLoginComplete}
-      />
-    );
-  }
-
-  // 이메일 입력 화면 (웹과 동일한 스타일)
-  if (currentScreen === 'email-input') {
-    return (
-      <EmailInputScreen
-        authState={authState}
-        emailForVerification={emailForVerification}
-        onBack={handleBack}
-        onEmailChange={setEmailForVerification}
-        onRequestVerification={async () => {
-          // 이메일 인증번호 요청
-          const emailAuthActions = new AuthActions(emailAuthManager);
-          const success = await emailAuthActions.requestEmailVerification(emailForVerification);
-          if (success) {
-            setCurrentScreen('verification-code');
-          }
-        }}
-      />
-    );
-  }
-
-  // 인증번호 입력 화면 (웹과 동일한 스타일)
-  if (currentScreen === 'verification-code') {
-    return (
-      <VerificationCodeScreen
-        emailForVerification={emailForVerification}
-        onBack={handleBack}
-        setCurrentAuthManager={(_manager: AuthManager) => {
-          // AuthManager 전환 로직은 useScreenNavigation에서 처리
-        }}
-        setCurrentProvider={(_provider: 'email' | 'google' | 'kakao' | 'naver') => {
-          // Provider 전환 로직은 useScreenNavigation에서 처리
-        }}
-        setCurrentScreen={(screen: string) => setCurrentScreen(screen as ScreenType)}
-        emailAuthManager={emailAuthManager}
-        refreshSession={refreshSession}
-        onLoginSuccess={handleLoginSuccess}
-      />
-    );
-  }
-
-  // Google 계속하기 화면
-  if (currentScreen === 'google-continue') {
-    return (
-      <OAuthContinueScreen
-        provider="google"
-        authState={authState}
-        onBack={handleBack}
-        onOAuthLogin={handleOAuthLogin}
-      />
-    );
-  }
-
-  // Kakao 계속하기 화면
-  if (currentScreen === 'kakao-continue') {
-    return (
-      <OAuthContinueScreen
-        provider="kakao"
-        authState={authState}
-        onBack={handleBack}
-        onOAuthLogin={handleOAuthLogin}
-      />
-    );
-  }
-
-  // Naver 계속하기 화면
-  if (currentScreen === 'naver-continue') {
-    return (
-      <OAuthContinueScreen
-        provider="naver"
-        authState={authState}
-        onBack={handleBack}
-        onOAuthLogin={handleOAuthLogin}
-      />
-    );
-  }
-
-  // 로그인 방식 선택 화면 (웹과 유사한 스타일)
+  // React Navigation으로 전환 - 조건부 렌더링 제거
   return (
-    <LoginSelectorScreen
-      authState={authState}
-      onBackToSplash={handleBackToSplash}
-      onEmailLogin={handleEmailLogin}
-      onOAuthContinue={handleOAuthContinue}
-      onGoogleLogin={handleGoogleLogin}
+    <AppNavigator
+      emailAuthManager={emailAuthManager}
+      googleAuthManager={googleAuthManager}
+      kakaoAuthManager={kakaoAuthManager}
+      naverAuthManager={naverAuthManager}
+      navigationHandlers={{
+        handleStartApp,
+        handleBackToSplash,
+        handleBack,
+        handleEmailLogin,
+        handleOAuthContinue,
+        handleLoginSuccess,
+        handleConnectNow,
+        handleLater,
+        handleGoToDashboard,
+        handleGoToLogin,
+        handleBackToLoginComplete,
+        handleOAuthLogin,
+        handleLogout,
+      }}
+      navigationState={{
+        currentAuthManager,
+        currentProvider,
+        emailForVerification,
+        setEmailForVerification,
+        authState,
+        clearError,
+        refreshSession,
+      }}
+      initialRouteName="Splash"
+      setNavigationRef={setNavigationRef}
     />
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@
  * @format
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { 
   StatusBar, 
   StyleSheet, 
@@ -124,12 +124,14 @@ function LoginMobileApp({
   });
   
   const { authState, clearError, refreshSession } = useAuthState(currentAuthManager);
-  
-  // AuthActions 인스턴스 생성 (현재 AuthManager 기준)
-  const authActions = new AuthActions(currentAuthManager);
 
   console.log('[App] 현재 인증 상태:', authState);
   console.log('[App] 현재 화면:', currentScreen);
+
+  // AuthActions 팩토리 함수: 항상 최신 currentAuthManager로 인스턴스 생성
+  const getAuthActions = useCallback(() => {
+    return new AuthActions(currentAuthManager);
+  }, [currentAuthManager]);
 
   // 인증 핸들러 훅 사용
   const { handleOAuthLogin, handleLogout } = useAuthHandlers({
@@ -142,7 +144,7 @@ function LoginMobileApp({
     switchToNaverAuth,
     clearError,
     handleBackToSplash,
-    authActions,
+    getAuthActions,
   });
 
   // React Navigation으로 전환 - 조건부 렌더링 제거

--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@
  * @format
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { 
   StatusBar, 
   StyleSheet, 
@@ -147,6 +147,56 @@ function LoginMobileApp({
     getAuthActions,
   });
 
+  // navigationHandlers 객체 메모이제이션 (불필요한 리렌더 방지)
+  const navigationHandlers = useMemo(() => ({
+    handleStartApp,
+    handleBackToSplash,
+    handleBack,
+    handleEmailLogin,
+    handleOAuthContinue,
+    handleLoginSuccess,
+    handleConnectNow,
+    handleLater,
+    handleGoToDashboard,
+    handleGoToLogin,
+    handleBackToLoginComplete,
+    handleOAuthLogin,
+    handleLogout,
+  }), [
+    handleStartApp,
+    handleBackToSplash,
+    handleBack,
+    handleEmailLogin,
+    handleOAuthContinue,
+    handleLoginSuccess,
+    handleConnectNow,
+    handleLater,
+    handleGoToDashboard,
+    handleGoToLogin,
+    handleBackToLoginComplete,
+    handleOAuthLogin,
+    handleLogout,
+  ]);
+
+  // navigationState 객체 메모이제이션 (불필요한 리렌더 방지)
+  const navigationState = useMemo(() => ({
+    currentAuthManager,
+    currentProvider,
+    emailForVerification,
+    setEmailForVerification,
+    authState,
+    clearError,
+    refreshSession,
+  }), [
+    currentAuthManager,
+    currentProvider,
+    emailForVerification,
+    setEmailForVerification,
+    authState,
+    clearError,
+    refreshSession,
+  ]);
+
   // React Navigation으로 전환 - 조건부 렌더링 제거
   return (
     <AppNavigator
@@ -154,30 +204,8 @@ function LoginMobileApp({
       googleAuthManager={googleAuthManager}
       kakaoAuthManager={kakaoAuthManager}
       naverAuthManager={naverAuthManager}
-      navigationHandlers={{
-        handleStartApp,
-        handleBackToSplash,
-        handleBack,
-        handleEmailLogin,
-        handleOAuthContinue,
-        handleLoginSuccess,
-        handleConnectNow,
-        handleLater,
-        handleGoToDashboard,
-        handleGoToLogin,
-        handleBackToLoginComplete,
-        handleOAuthLogin,
-        handleLogout,
-      }}
-      navigationState={{
-        currentAuthManager,
-        currentProvider,
-        emailForVerification,
-        setEmailForVerification,
-        authState,
-        clearError,
-        refreshSession,
-      }}
+      navigationHandlers={navigationHandlers}
+      navigationState={navigationState}
       initialRouteName="Splash"
       setNavigationRef={setNavigationRef}
       onNavigationStateChange={onNavigationStateChange}

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * @format
  */
 
+import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';

--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@
  */
 
 import 'react-native-gesture-handler';
+import { enableScreens } from 'react-native-screens';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';
+
+// react-native-screens 최적화 활성화 (네이티브 스크린 사용으로 메모리/전환 성능 향상)
+enableScreens(true);
 
 AppRegistry.registerComponent(appName, () => App);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,13 @@
       "dependencies": {
         "@growgrammers/auth-core": "npm:growgrammers-auth-core@^0.2.2",
         "@react-native/new-app-screen": "0.81.4",
+        "@react-navigation/native": "^7.1.19",
+        "@react-navigation/native-stack": "^7.6.2",
         "react": "19.1.0",
         "react-native": "0.81.4",
-        "react-native-safe-area-context": "^5.5.2"
+        "react-native-gesture-handler": "^2.29.1",
+        "react-native-safe-area-context": "^5.5.2",
+        "react-native-screens": "^4.18.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -1744,6 +1748,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "dev": true,
@@ -2865,6 +2881,99 @@
         }
       }
     },
+    "node_modules/@react-navigation/core": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.13.0.tgz",
+      "integrity": "sha512-Fc/SO23HnlGnkou/z8JQUzwEMvhxuUhr4rdPTIZp/c8q1atq3k632Nfh8fEiGtk+MP1wtIvXdN2a5hBIWpLq3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/routers": "^7.5.1",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "query-string": "^7.1.3",
+        "react-is": "^19.1.0",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-navigation/elements": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.8.1.tgz",
+      "integrity": "sha512-MLmuS5kPAeAFFOylw89WGjgEFBqGj/KBK6ZrFrAOqLnTqEzk52/SO1olb5GB00k6ZUCDZKJOp1BrLXslxE6TgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@react-native-masked-view/masked-view": ">= 0.2.0",
+        "@react-navigation/native": "^7.1.19",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-masked-view/masked-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.19.tgz",
+      "integrity": "sha512-fM7q8di4Q8sp2WUhiUWOe7bEDRyRhbzsKQOd5N2k+lHeCx3UncsRYuw4Q/KN0EovM3wWKqMMmhy/YWuEO04kgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.13.0",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.6.2.tgz",
+      "integrity": "sha512-CB6chGNLwJYiyOeyCNUKx33yT7XJSwRZIeKHf4S1vs+Oqu3u9zMnvGUIsesNgbgX0xy16gBqYsrWgr0ZczBTtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.8.1",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.19",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.5.1.tgz",
+      "integrity": "sha512-pxipMW/iEBSUrjxz2cDD7fNwkqR4xoi0E/PcfTQGCcdJwLoaxzab5kSadBLj1MTJyT0YRrOXL9umHpXtp+Dv4w==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "devOptional": true,
@@ -2940,6 +3049,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4125,6 +4240,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -4138,6 +4266,16 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -4387,6 +4525,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dedent": {
@@ -5360,7 +5507,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5449,6 +5595,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -5885,6 +6040,21 @@
       "dependencies": {
         "hermes-estree": "0.29.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7952,6 +8122,24 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -8531,6 +8719,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "license": "MIT",
@@ -8612,6 +8818,18 @@
         }
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "license": "MIT"
@@ -8671,9 +8889,38 @@
         }
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.29.1.tgz",
+      "integrity": "sha512-du3qmv0e3Sm7qsd9SfmHps+AggLiylcBBQ8ztz7WUtd8ZjKs5V3kekAbi9R2W9bRLSg47Ntp4GGMYZOhikQdZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.1",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.18.0.tgz",
+      "integrity": "sha512-mRTLWL7Uc1p/RFNveEIIrhP22oxHduC2ZnLr/2iHwBeYpGXR0rJZ7Bgc0ktxQSHRjWTPT70qc/7yd4r9960PBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -9171,6 +9418,15 @@
       "version": "1.2.0",
       "license": "ISC"
     },
+    "node_modules/sf-symbols-typescript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sf-symbols-typescript/-/sf-symbols-typescript-2.1.0.tgz",
+      "integrity": "sha512-ezT7gu/SHTPIOEEoG6TF+O0m5eewl0ZDAO4AtdBi5HjsrUI6JdCG17+Q8+aKp0heM06wZKApRCn5olNbs0Wb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "devOptional": true,
@@ -9272,6 +9528,21 @@
       "version": "3.0.7",
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "devOptional": true,
@@ -9337,6 +9608,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "license": "BSD-3-Clause"
@@ -9396,6 +9676,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -9948,6 +10237,24 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "devOptional": true,
@@ -9991,6 +10298,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
   "dependencies": {
     "@growgrammers/auth-core": "npm:growgrammers-auth-core@^0.2.2",
     "@react-native/new-app-screen": "0.81.4",
+    "@react-navigation/native": "^7.1.19",
+    "@react-navigation/native-stack": "^7.6.2",
     "react": "19.1.0",
     "react-native": "0.81.4",
-    "react-native-safe-area-context": "^5.5.2"
+    "react-native-gesture-handler": "^2.29.1",
+    "react-native-safe-area-context": "^5.5.2",
+    "react-native-screens": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/auth/AuthConfig.ts
+++ b/src/auth/AuthConfig.ts
@@ -874,6 +874,8 @@ export class ReactNativeAuthFactory {
     this.bridge = null;
     this.emailAuthManager = null;
     this.googleAuthManager = null;
+    this.kakaoAuthManager = null;  
+    this.naverAuthManager = null;  
   }
 }
 

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -17,7 +17,7 @@ interface UseAuthHandlersProps {
   switchToNaverAuth: () => void;
   clearError: () => void;
   handleBackToSplash: () => void;
-  authActions: AuthActions;
+  getAuthActions: () => AuthActions;
 }
 
 interface UseAuthHandlersReturn {
@@ -38,7 +38,7 @@ export function useAuthHandlers({
   switchToNaverAuth,
   clearError,
   handleBackToSplash,
-  authActions,
+  getAuthActions,
 }: UseAuthHandlersProps): UseAuthHandlersReturn {
   // OAuth 계속하기에서 실제 로그인 시도
   const handleOAuthLogin = useCallback(async (provider: 'google' | 'kakao' | 'naver') => {
@@ -89,6 +89,8 @@ export function useAuthHandlers({
     console.log('[useAuthHandlers] 로그아웃 시작');
     
     try {
+      // 항상 최신 AuthManager로 AuthActions 인스턴스 생성
+      const authActions = getAuthActions();
       const success = await authActions.signOut();
       if (success) {
         console.log('[useAuthHandlers] 로그아웃 성공');
@@ -104,7 +106,7 @@ export function useAuthHandlers({
       // 예외 발생해도 스플래시 화면으로 이동 (로컬 세션 정리)
       handleBackToSplash();
     }
-  }, [authActions, handleBackToSplash]);
+  }, [getAuthActions, handleBackToSplash]);
 
   return {
     handleOAuthLogin,

--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -1,0 +1,115 @@
+/**
+ * useAuthHandlers - 인증 관련 핸들러들을 관리하는 훅
+ * App.tsx에서 핸들러 로직을 분리하여 재사용성과 테스트 용이성 향상
+ */
+
+import { useCallback } from 'react';
+import type { AuthManager } from '@growgrammers/auth-core';
+import { AuthActions } from '../utils/AuthEventHandler';
+
+interface UseAuthHandlersProps {
+  emailAuthManager: AuthManager;
+  googleAuthManager: AuthManager;
+  kakaoAuthManager: AuthManager;
+  naverAuthManager: AuthManager;
+  switchToGoogleAuth: () => void;
+  switchToKakaoAuth: () => void;
+  switchToNaverAuth: () => void;
+  clearError: () => void;
+  handleBackToSplash: () => void;
+  authActions: AuthActions;
+}
+
+interface UseAuthHandlersReturn {
+  handleOAuthLogin: (provider: 'google' | 'kakao' | 'naver') => Promise<void>;
+  handleLogout: () => Promise<void>;
+}
+
+/**
+ * 인증 핸들러 훅
+ * OAuth 로그인 및 로그아웃 핸들러를 제공
+ */
+export function useAuthHandlers({
+  googleAuthManager,
+  kakaoAuthManager,
+  naverAuthManager,
+  switchToGoogleAuth,
+  switchToKakaoAuth,
+  switchToNaverAuth,
+  clearError,
+  handleBackToSplash,
+  authActions,
+}: UseAuthHandlersProps): UseAuthHandlersReturn {
+  // OAuth 계속하기에서 실제 로그인 시도
+  const handleOAuthLogin = useCallback(async (provider: 'google' | 'kakao' | 'naver') => {
+    console.log(`[useAuthHandlers] ${provider} 로그인 시작`);
+    
+    // 해당 AuthManager로 전환
+    if (provider === 'google') {
+      switchToGoogleAuth();
+    } else if (provider === 'kakao') {
+      switchToKakaoAuth();
+    } else if (provider === 'naver') {
+      switchToNaverAuth();
+    }
+    
+    clearError();
+    
+    try {
+      let oauthAuthActions;
+      if (provider === 'google') {
+        oauthAuthActions = new AuthActions(googleAuthManager);
+      } else if (provider === 'kakao') {
+        oauthAuthActions = new AuthActions(kakaoAuthManager);
+      } else {
+        oauthAuthActions = new AuthActions(naverAuthManager);
+      }
+      
+      const success = await oauthAuthActions.startOAuth(provider);
+      if (success) {
+        console.log(`[useAuthHandlers] ${provider} 로그인 시작 성공`);
+      } else {
+        console.log(`[useAuthHandlers] ${provider} 로그인 시작 실패`);
+      }
+    } catch (error) {
+      console.error(`[useAuthHandlers] ${provider} 로그인 예외:`, error);
+    }
+  }, [
+    switchToGoogleAuth,
+    switchToKakaoAuth,
+    switchToNaverAuth,
+    clearError,
+    googleAuthManager,
+    kakaoAuthManager,
+    naverAuthManager,
+  ]);
+
+  // 로그아웃 핸들러
+  const handleLogout = useCallback(async () => {
+    console.log('[useAuthHandlers] 로그아웃 시작');
+    
+    try {
+      const success = await authActions.signOut();
+      if (success) {
+        console.log('[useAuthHandlers] 로그아웃 성공');
+        // 웹 앱과 동일하게 스플래시 화면으로 리다이렉트
+        handleBackToSplash();
+      } else {
+        console.log('[useAuthHandlers] 로그아웃 실패');
+        // 실패해도 스플래시 화면으로 이동 (로컬 세션 정리)
+        handleBackToSplash();
+      }
+    } catch (error) {
+      console.error('[useAuthHandlers] 로그아웃 예외:', error);
+      // 예외 발생해도 스플래시 화면으로 이동 (로컬 세션 정리)
+      handleBackToSplash();
+    }
+  }, [authActions, handleBackToSplash]);
+
+  return {
+    handleOAuthLogin,
+    handleLogout,
+  };
+}
+
+

--- a/src/hooks/useScreenNavigation.ts
+++ b/src/hooks/useScreenNavigation.ts
@@ -44,6 +44,7 @@ interface UseScreenNavigationReturn {
   switchToNaverAuth: () => void;
   // React Navigation 통합
   setNavigationRef: (navigation: NavigationContainerRef<RootStackParamList> | null) => void;
+  onNavigationStateChange: (state: NavigationState<RootStackParamList> | undefined) => void;
 }
 
 export function useScreenNavigation({
@@ -59,7 +60,6 @@ export function useScreenNavigation({
   
   // React Navigation ref
   const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
   
   // 현재 AuthManager의 인증 상태 감시
   const { authState } = useAuthState(currentAuthManager);
@@ -84,7 +84,7 @@ export function useScreenNavigation({
     
     if (navigationRef.current?.isReady()) {
       // React Navigation의 애니메이션이 완료될 때까지 상태 업데이트를 지연
-      // 상태는 위의 state 이벤트 리스너에서 자동으로 동기화됩니다
+      // 상태는 NavigationContainer의 onStateChange에서 자동으로 동기화됩니다
       navigationRef.current.navigate(routeName as any);
     } else {
       // Navigation이 준비되지 않았을 때만 직접 상태 업데이트
@@ -92,15 +92,6 @@ export function useScreenNavigation({
     }
   }, []);
 
-  // 컴포넌트 언마운트 시 리스너 정리
-  useEffect(() => {
-    return () => {
-      if (unsubscribeRef.current) {
-        unsubscribeRef.current();
-        unsubscribeRef.current = null;
-      }
-    };
-  }, []);
 
   // 소셜 로그인 성공 시 LoginComplete 화면으로 자동 이동 (한 번만)
   useEffect(() => {
@@ -149,31 +140,21 @@ export function useScreenNavigation({
     }
   }, [currentProvider, naverAuthManager]);
 
-  // React Navigation ref 설정 및 상태 동기화 리스너 등록
+  // React Navigation ref 설정 (단순화)
   const setNavigationRef = useCallback((navigation: NavigationContainerRef<RootStackParamList> | null) => {
-    // 기존 리스너 제거
-    if (unsubscribeRef.current) {
-      unsubscribeRef.current();
-      unsubscribeRef.current = null;
-    }
-    
     navigationRef.current = navigation;
-    
-    // 새로운 리스너 등록
-    if (navigation) {
-      const unsubscribe = navigation.addListener('state', (e) => {
-        const state = e.data.state as NavigationState<RootStackParamList> | undefined;
-        if (state) {
-          const route = state.routes[state.index];
-          if (route) {
-            const screen = routeNameToScreenType[route.name as keyof RootStackParamList];
-            if (screen) {
-              setCurrentScreen(screen);
-            }
-          }
+  }, []);
+
+  // 네비게이션 상태 변경 핸들러 (NavigationContainer의 onStateChange에서 호출)
+  const onNavigationStateChange = useCallback((state: NavigationState<RootStackParamList> | undefined) => {
+    if (state) {
+      const route = state.routes[state.index];
+      if (route) {
+        const screen = routeNameToScreenType[route.name as keyof RootStackParamList];
+        if (screen) {
+          setCurrentScreen(screen);
         }
-      });
-      unsubscribeRef.current = unsubscribe;
+      }
     }
   }, [routeNameToScreenType]);
 
@@ -270,5 +251,6 @@ export function useScreenNavigation({
     switchToKakaoAuth,
     switchToNaverAuth,
     setNavigationRef,
+    onNavigationStateChange,
   };
 }

--- a/src/hooks/useScreenNavigation.ts
+++ b/src/hooks/useScreenNavigation.ts
@@ -3,11 +3,13 @@
  * App.tsx에서 화면 전환 로직을 분리
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { AuthManager } from '@growgrammers/auth-core';
 import { useAuthState } from '../utils/AuthEventHandler';
-
-export type ScreenType = 'splash' | 'login' | 'email-input' | 'verification-code' | 'google-continue' | 'kakao-continue' | 'naver-continue' | 'login-complete' | 'service-main' | 'dashboard';
+import type { NavigationContainerRef } from '@react-navigation/native';
+import { NavigationState } from '@react-navigation/native';
+import type { RootStackParamList, ScreenType } from '../navigation/types';
+import { screenTypeToRouteName } from '../navigation/types';
 
 export type ProviderType = 'email' | 'google' | 'kakao' | 'naver';
 
@@ -40,6 +42,8 @@ interface UseScreenNavigationReturn {
   switchToEmailAuth: () => void;
   switchToKakaoAuth: () => void;
   switchToNaverAuth: () => void;
+  // React Navigation 통합
+  setNavigationRef: (navigation: NavigationContainerRef<RootStackParamList> | null) => void;
 }
 
 export function useScreenNavigation({
@@ -53,8 +57,50 @@ export function useScreenNavigation({
   const [currentProvider, setCurrentProvider] = useState<ProviderType>('email');
   const [emailForVerification, setEmailForVerification] = useState<string>('');
   
+  // React Navigation ref
+  const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  
   // 현재 AuthManager의 인증 상태 감시
   const { authState } = useAuthState(currentAuthManager);
+  
+  // route name을 ScreenType으로 변환하는 맵
+  const routeNameToScreenType = useMemo<Record<keyof RootStackParamList, ScreenType>>(() => ({
+    'Splash': 'splash',
+    'Login': 'login',
+    'EmailInput': 'email-input',
+    'VerificationCode': 'verification-code',
+    'GoogleContinue': 'google-continue',
+    'KakaoContinue': 'kakao-continue',
+    'NaverContinue': 'naver-continue',
+    'LoginComplete': 'login-complete',
+    'ServiceMain': 'service-main',
+    'Dashboard': 'dashboard',
+  }), []);
+  
+  // ScreenType을 React Navigation route name으로 변환하는 헬퍼
+  const navigateToScreen = useCallback((screen: ScreenType) => {
+    const routeName = screenTypeToRouteName(screen);
+    
+    if (navigationRef.current?.isReady()) {
+      // React Navigation의 애니메이션이 완료될 때까지 상태 업데이트를 지연
+      // 상태는 위의 state 이벤트 리스너에서 자동으로 동기화됩니다
+      navigationRef.current.navigate(routeName as any);
+    } else {
+      // Navigation이 준비되지 않았을 때만 직접 상태 업데이트
+      setCurrentScreen(screen);
+    }
+  }, []);
+
+  // 컴포넌트 언마운트 시 리스너 정리
+  useEffect(() => {
+    return () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    };
+  }, []);
 
   // 소셜 로그인 성공 시 LoginComplete 화면으로 자동 이동 (한 번만)
   useEffect(() => {
@@ -63,9 +109,9 @@ export function useScreenNavigation({
         currentScreen !== 'dashboard' && 
         currentScreen !== 'service-main') {
       console.log('[useScreenNavigation] 소셜 로그인 성공 감지 - LoginComplete 화면으로 이동');
-      setCurrentScreen('login-complete');
+      navigateToScreen('login-complete');
     }
-  }, [authState.loginSuccessTriggered, authState.isLoggedIn, currentScreen]);
+  }, [authState.loginSuccessTriggered, authState.isLoggedIn, currentScreen, navigateToScreen]);
 
   // 구글 AuthManager로 전환
   const switchToGoogleAuth = useCallback(() => {
@@ -103,70 +149,102 @@ export function useScreenNavigation({
     }
   }, [currentProvider, naverAuthManager]);
 
+  // React Navigation ref 설정 및 상태 동기화 리스너 등록
+  const setNavigationRef = useCallback((navigation: NavigationContainerRef<RootStackParamList> | null) => {
+    // 기존 리스너 제거
+    if (unsubscribeRef.current) {
+      unsubscribeRef.current();
+      unsubscribeRef.current = null;
+    }
+    
+    navigationRef.current = navigation;
+    
+    // 새로운 리스너 등록
+    if (navigation) {
+      const unsubscribe = navigation.addListener('state', (e) => {
+        const state = e.data.state as NavigationState<RootStackParamList> | undefined;
+        if (state) {
+          const route = state.routes[state.index];
+          if (route) {
+            const screen = routeNameToScreenType[route.name as keyof RootStackParamList];
+            if (screen) {
+              setCurrentScreen(screen);
+            }
+          }
+        }
+      });
+      unsubscribeRef.current = unsubscribe;
+    }
+  }, [routeNameToScreenType]);
+
   // 스플래시에서 시작하기 버튼 핸들러
   const handleStartApp = useCallback(() => {
-    setCurrentScreen('login');
-  }, []);
+    navigateToScreen('login');
+  }, [navigateToScreen]);
 
   // 스플래시로 돌아가기 핸들러
   const handleBackToSplash = useCallback(() => {
-    setCurrentScreen('splash');
+    navigateToScreen('splash');
     // 로그아웃 시 이메일 상태 초기화
     setEmailForVerification('');
-  }, []);
+  }, [navigateToScreen]);
 
   // 뒤로가기 핸들러
   const handleBack = useCallback(() => {
-    setCurrentScreen('login');
-  }, []);
+    if (navigationRef.current?.isReady() && navigationRef.current.canGoBack()) {
+      navigationRef.current.goBack();
+    } else {
+      navigateToScreen('login');
+    }
+  }, [navigateToScreen]);
 
   // 이메일 로그인 시작 핸들러
   const handleEmailLogin = useCallback(() => {
     console.log('[useScreenNavigation] 이메일 로그인 시작');
     switchToEmailAuth();
-    setCurrentScreen('email-input');
-  }, [switchToEmailAuth]);
+    navigateToScreen('email-input');
+  }, [switchToEmailAuth, navigateToScreen]);
 
   // OAuth 계속하기 화면으로 이동
   const handleOAuthContinue = useCallback((provider: 'google' | 'kakao' | 'naver') => {
-    setCurrentScreen(`${provider}-continue` as ScreenType);
-  }, []);
+    navigateToScreen(`${provider}-continue` as ScreenType);
+  }, [navigateToScreen]);
 
   // 로그인 성공 핸들러
   const handleLoginSuccess = useCallback(() => {
     console.log('[useScreenNavigation] 로그인 성공 - LoginComplete 화면으로 이동');
-    setCurrentScreen('login-complete');
-  }, []);
+    navigateToScreen('login-complete');
+  }, [navigateToScreen]);
 
   // 지금 연동하러 가기 (대시보드로)
   const handleConnectNow = useCallback(() => {
     console.log('[useScreenNavigation] 지금 연동하러 가기 - 대시보드로 이동');
-    setCurrentScreen('dashboard');
-  }, []);
+    navigateToScreen('dashboard');
+  }, [navigateToScreen]);
 
   // 다음에 할게요 (서비스 메인으로)
   const handleLater = useCallback(() => {
     console.log('[useScreenNavigation] 다음에 할게요 - 서비스 메인으로 이동');
-    setCurrentScreen('service-main');
-  }, []);
+    navigateToScreen('service-main');
+  }, [navigateToScreen]);
 
   // 회원정보 확인 (대시보드로)
   const handleGoToDashboard = useCallback(() => {
     console.log('[useScreenNavigation] 회원정보 확인 - 대시보드로 이동');
-    setCurrentScreen('dashboard');
-  }, []);
+    navigateToScreen('dashboard');
+  }, [navigateToScreen]);
 
   // 로그인하러 가기 (로그인 선택으로)
   const handleGoToLogin = useCallback(() => {
     console.log('[useScreenNavigation] 로그인하러 가기 - 로그인 선택으로 이동');
-    setCurrentScreen('login');
-  }, []);
+    navigateToScreen('login');
+  }, [navigateToScreen]);
 
   // 로그인 완료 화면으로 돌아가기
   const handleBackToLoginComplete = useCallback(() => {
     console.log('[useScreenNavigation] 로그인 완료 화면으로 돌아가기');
-    setCurrentScreen('login-complete');
-  }, []);
+    navigateToScreen('login-complete');
+  }, [navigateToScreen]);
 
 
   return {
@@ -174,7 +252,7 @@ export function useScreenNavigation({
     currentAuthManager,
     currentProvider,
     emailForVerification,
-    setCurrentScreen,
+    setCurrentScreen: navigateToScreen, // React Navigation으로 통합
     setEmailForVerification,
     handleStartApp,
     handleBackToSplash,
@@ -191,5 +269,6 @@ export function useScreenNavigation({
     switchToEmailAuth,
     switchToKakaoAuth,
     switchToNaverAuth,
+    setNavigationRef,
   };
 }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,8 +3,8 @@
  * 기존 화면 플로우를 유지하면서 React Navigation으로 전환
  */
 
-import React, { useRef } from 'react';
-import { NavigationContainer, NavigationContainerRef, NavigationState } from '@react-navigation/native';
+import React, { useRef, useCallback } from 'react';
+import { NavigationContainer, NavigationContainerRef, NavigationState, ParamListBase } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { AuthManager } from '@growgrammers/auth-core';
 import type { RootStackParamList } from './types';
@@ -77,6 +77,49 @@ export function AppNavigator({
 }: AppNavigatorProps) {
   const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
 
+  // onStateChange 핸들러 래퍼 (타입 호환성 처리)
+  // NavigationContainer의 onStateChange는 일반적인 NavigationState를 기대하므로
+  // 타입 단언을 통해 RootStackParamList로 변환
+  const handleStateChange = useCallback((
+    state: NavigationState<ParamListBase> | undefined
+  ) => {
+    if (onNavigationStateChange) {
+      // NavigationContainer가 RootStackParamList로 타입화되어 있으므로
+      // 실제로는 RootStackParamList 타입이지만 타입 시스템이 이를 인식하지 못함
+      onNavigationStateChange(state as NavigationState<RootStackParamList> | undefined);
+    }
+  }, [onNavigationStateChange]);
+
+  // inline handler 메모이제이션 (불필요한 리렌더 방지)
+  const handleGoogleLogin = useCallback(() => {
+    navigationHandlers.handleOAuthContinue('google');
+  }, [navigationHandlers]);
+
+  // EmailInputScreen의 onRequestVerification 핸들러 메모이제이션
+  const handleRequestVerification = useCallback(async (navigation: any) => {
+    const { AuthActions } = await import('../utils/AuthEventHandler');
+    const emailAuthActions = new AuthActions(emailAuthManager);
+    const success = await emailAuthActions.requestEmailVerification(
+      navigationState.emailForVerification
+    );
+    if (success) {
+      navigation.navigate('VerificationCode');
+    }
+  }, [emailAuthManager, navigationState.emailForVerification]);
+
+  // VerificationCodeScreen의 빈 핸들러들 메모이제이션 (불필요한 리렌더 방지)
+  const emptySetCurrentAuthManager = useCallback((_manager: AuthManager) => {
+    // AuthManager 전환 로직은 useScreenNavigation에서 처리
+  }, []);
+  
+  const emptySetCurrentProvider = useCallback((_provider: 'email' | 'google' | 'kakao' | 'naver') => {
+    // Provider 전환 로직은 useScreenNavigation에서 처리
+  }, []);
+  
+  const emptySetCurrentScreen = useCallback((_screen: string) => {
+    // React Navigation으로 자동 처리
+  }, []);
+
   return (
     <NavigationContainer<RootStackParamList>
       ref={(ref) => {
@@ -85,7 +128,7 @@ export function AppNavigator({
           setNavigationRef(ref);
         }
       }}
-      onStateChange={onNavigationStateChange}
+      onStateChange={handleStateChange}
     >
       <Stack.Navigator
         initialRouteName={initialRouteName}
@@ -111,7 +154,7 @@ export function AppNavigator({
               onBackToSplash={navigationHandlers.handleBackToSplash}
               onEmailLogin={navigationHandlers.handleEmailLogin}
               onOAuthContinue={navigationHandlers.handleOAuthContinue}
-              onGoogleLogin={() => navigationHandlers.handleOAuthContinue('google')}
+              onGoogleLogin={handleGoogleLogin}
             />
           )}
         </Stack.Screen>
@@ -124,16 +167,7 @@ export function AppNavigator({
               emailForVerification={navigationState.emailForVerification}
               onBack={navigationHandlers.handleBack}
               onEmailChange={navigationState.setEmailForVerification}
-              onRequestVerification={async () => {
-                const { AuthActions } = await import('../utils/AuthEventHandler');
-                const emailAuthActions = new AuthActions(emailAuthManager);
-                const success = await emailAuthActions.requestEmailVerification(
-                  navigationState.emailForVerification
-                );
-                if (success) {
-                  props.navigation.navigate('VerificationCode');
-                }
-              }}
+              onRequestVerification={() => handleRequestVerification(props.navigation)}
             />
           )}
         </Stack.Screen>
@@ -144,15 +178,9 @@ export function AppNavigator({
               {...props}
               emailForVerification={navigationState.emailForVerification}
               onBack={navigationHandlers.handleBack}
-              setCurrentAuthManager={(_manager: AuthManager) => {
-                // AuthManager 전환 로직은 useScreenNavigation에서 처리
-              }}
-              setCurrentProvider={(_provider: 'email' | 'google' | 'kakao' | 'naver') => {
-                // Provider 전환 로직은 useScreenNavigation에서 처리
-              }}
-              setCurrentScreen={(_screen: string) => {
-                // React Navigation으로 자동 처리
-              }}
+              setCurrentAuthManager={emptySetCurrentAuthManager}
+              setCurrentProvider={emptySetCurrentProvider}
+              setCurrentScreen={emptySetCurrentScreen}
               emailAuthManager={emailAuthManager}
               refreshSession={navigationState.refreshSession}
               onLoginSuccess={navigationHandlers.handleLoginSuccess}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useRef } from 'react';
-import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainer, NavigationContainerRef, NavigationState } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { AuthManager } from '@growgrammers/auth-core';
 import type { RootStackParamList } from './types';
@@ -60,6 +60,8 @@ export interface AppNavigatorProps {
   initialRouteName?: keyof RootStackParamList;
   // Navigation ref setter (useScreenNavigation과 통합)
   setNavigationRef?: (navigation: NavigationContainerRef<RootStackParamList> | null) => void;
+  // Navigation state change handler (공식 onStateChange prop 사용)
+  onNavigationStateChange?: (state: NavigationState<RootStackParamList> | undefined) => void;
 }
 
 export function AppNavigator({
@@ -71,6 +73,7 @@ export function AppNavigator({
   navigationState,
   initialRouteName = 'Splash',
   setNavigationRef,
+  onNavigationStateChange,
 }: AppNavigatorProps) {
   const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
 
@@ -82,6 +85,7 @@ export function AppNavigator({
           setNavigationRef(ref);
         }
       }}
+      onStateChange={onNavigationStateChange}
     >
       <Stack.Navigator
         initialRouteName={initialRouteName}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,0 +1,233 @@
+/**
+ * React Navigation App Navigator
+ * 기존 화면 플로우를 유지하면서 React Navigation으로 전환
+ */
+
+import React, { useRef } from 'react';
+import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { AuthManager } from '@growgrammers/auth-core';
+import type { RootStackParamList } from './types';
+
+// Screen Components
+import { SplashScreen } from '../screens/SplashScreen';
+import { LoginSelectorScreen } from '../screens/LoginSelectorScreen';
+import { EmailInputScreen } from '../screens/EmailInputScreen';
+import { VerificationCodeScreen } from '../screens/VerificationCodeScreen';
+import { OAuthContinueScreen } from '../screens/OAuthContinueScreen';
+import { LoginCompleteScreen } from '../screens/LoginCompleteScreen';
+import { ServiceMainScreen } from '../screens/ServiceMainScreen';
+import { DashboardScreen } from '../screens/DashboardScreen';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export interface AppNavigatorProps {
+  // AuthManagers
+  emailAuthManager: AuthManager;
+  googleAuthManager: AuthManager;
+  kakaoAuthManager: AuthManager;
+  naverAuthManager: AuthManager;
+  
+  // Navigation handlers (기존 로직 유지)
+  navigationHandlers: {
+    handleStartApp: () => void;
+    handleBackToSplash: () => void;
+    handleBack: () => void;
+    handleEmailLogin: () => void;
+    handleOAuthContinue: (provider: 'google' | 'kakao' | 'naver') => void;
+    handleLoginSuccess: () => void;
+    handleConnectNow: () => void;
+    handleLater: () => void;
+    handleGoToDashboard: () => void;
+    handleGoToLogin: () => void;
+    handleBackToLoginComplete: () => void;
+    handleOAuthLogin: (provider: 'google' | 'kakao' | 'naver') => Promise<void>;
+    handleLogout: () => Promise<void>;
+  };
+  
+  // Navigation state
+  navigationState: {
+    currentAuthManager: AuthManager;
+    currentProvider: 'email' | 'google' | 'kakao' | 'naver';
+    emailForVerification: string;
+    setEmailForVerification: (email: string) => void;
+    authState: any;
+    clearError: () => void;
+    refreshSession: () => Promise<void>;
+  };
+  
+  // Initial route
+  initialRouteName?: keyof RootStackParamList;
+  // Navigation ref setter (useScreenNavigation과 통합)
+  setNavigationRef?: (navigation: NavigationContainerRef<RootStackParamList> | null) => void;
+}
+
+export function AppNavigator({
+  emailAuthManager,
+  googleAuthManager: _googleAuthManager,
+  kakaoAuthManager: _kakaoAuthManager,
+  naverAuthManager: _naverAuthManager,
+  navigationHandlers,
+  navigationState,
+  initialRouteName = 'Splash',
+  setNavigationRef,
+}: AppNavigatorProps) {
+  const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
+
+  return (
+    <NavigationContainer<RootStackParamList>
+      ref={(ref) => {
+        navigationRef.current = ref;
+        if (setNavigationRef) {
+          setNavigationRef(ref);
+        }
+      }}
+    >
+      <Stack.Navigator
+        initialRouteName={initialRouteName}
+        screenOptions={{
+          headerShown: false,
+          animation: 'none',
+        }}
+      >
+        <Stack.Screen name="Splash">
+          {(props) => (
+            <SplashScreen
+              {...props}
+              onStartApp={navigationHandlers.handleStartApp}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="Login">
+          {(props) => (
+            <LoginSelectorScreen
+              {...props}
+              authState={navigationState.authState}
+              onBackToSplash={navigationHandlers.handleBackToSplash}
+              onEmailLogin={navigationHandlers.handleEmailLogin}
+              onOAuthContinue={navigationHandlers.handleOAuthContinue}
+              onGoogleLogin={() => navigationHandlers.handleOAuthContinue('google')}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="EmailInput">
+          {(props) => (
+            <EmailInputScreen
+              {...props}
+              authState={navigationState.authState}
+              emailForVerification={navigationState.emailForVerification}
+              onBack={navigationHandlers.handleBack}
+              onEmailChange={navigationState.setEmailForVerification}
+              onRequestVerification={async () => {
+                const { AuthActions } = await import('../utils/AuthEventHandler');
+                const emailAuthActions = new AuthActions(emailAuthManager);
+                const success = await emailAuthActions.requestEmailVerification(
+                  navigationState.emailForVerification
+                );
+                if (success) {
+                  props.navigation.navigate('VerificationCode');
+                }
+              }}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="VerificationCode">
+          {(props) => (
+            <VerificationCodeScreen
+              {...props}
+              emailForVerification={navigationState.emailForVerification}
+              onBack={navigationHandlers.handleBack}
+              setCurrentAuthManager={(_manager: AuthManager) => {
+                // AuthManager 전환 로직은 useScreenNavigation에서 처리
+              }}
+              setCurrentProvider={(_provider: 'email' | 'google' | 'kakao' | 'naver') => {
+                // Provider 전환 로직은 useScreenNavigation에서 처리
+              }}
+              setCurrentScreen={(_screen: string) => {
+                // React Navigation으로 자동 처리
+              }}
+              emailAuthManager={emailAuthManager}
+              refreshSession={navigationState.refreshSession}
+              onLoginSuccess={navigationHandlers.handleLoginSuccess}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="GoogleContinue">
+          {(props) => (
+            <OAuthContinueScreen
+              {...props}
+              provider="google"
+              authState={navigationState.authState}
+              onBack={navigationHandlers.handleBack}
+              onOAuthLogin={navigationHandlers.handleOAuthLogin}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="KakaoContinue">
+          {(props) => (
+            <OAuthContinueScreen
+              {...props}
+              provider="kakao"
+              authState={navigationState.authState}
+              onBack={navigationHandlers.handleBack}
+              onOAuthLogin={navigationHandlers.handleOAuthLogin}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="NaverContinue">
+          {(props) => (
+            <OAuthContinueScreen
+              {...props}
+              provider="naver"
+              authState={navigationState.authState}
+              onBack={navigationHandlers.handleBack}
+              onOAuthLogin={navigationHandlers.handleOAuthLogin}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="LoginComplete">
+          {(props) => (
+            <LoginCompleteScreen
+              {...props}
+              onConnectNow={navigationHandlers.handleConnectNow}
+              onLater={navigationHandlers.handleLater}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="ServiceMain">
+          {(props) => (
+            <ServiceMainScreen
+              {...props}
+              isAuthenticated={navigationState.authState.isLoggedIn}
+              onGoToDashboard={navigationHandlers.handleGoToDashboard}
+              onLogout={navigationHandlers.handleLogout}
+              onGoToLogin={navigationHandlers.handleGoToLogin}
+              onBackToLoginComplete={navigationHandlers.handleBackToLoginComplete}
+            />
+          )}
+        </Stack.Screen>
+
+        <Stack.Screen name="Dashboard">
+          {(props) => (
+            <DashboardScreen
+              {...props}
+              authState={navigationState.authState}
+              currentProvider={navigationState.currentProvider}
+              onLogout={navigationHandlers.handleLogout}
+              onBackToLoginComplete={navigationHandlers.handleBackToLoginComplete}
+            />
+          )}
+        </Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,11 +3,13 @@
  * 기존 화면 플로우를 유지하면서 React Navigation으로 전환
  */
 
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
+import { BackHandler, Alert, Platform } from 'react-native';
 import { NavigationContainer, NavigationContainerRef, NavigationState, ParamListBase } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { AuthManager } from '@growgrammers/auth-core';
 import type { RootStackParamList } from './types';
+import type { AuthState } from '../utils/AuthEventHandler';
 
 // Screen Components
 import { SplashScreen } from '../screens/SplashScreen';
@@ -51,7 +53,7 @@ export interface AppNavigatorProps {
     currentProvider: 'email' | 'google' | 'kakao' | 'naver';
     emailForVerification: string;
     setEmailForVerification: (email: string) => void;
-    authState: any;
+    authState: AuthState;
     clearError: () => void;
     refreshSession: () => Promise<void>;
   };
@@ -119,6 +121,50 @@ export function AppNavigator({
   const emptySetCurrentScreen = useCallback((_screen: string) => {
     // React Navigation으로 자동 처리
   }, []);
+
+  // Android 하드웨어 뒤로가기 처리
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+
+    const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (!navigationRef.current?.isReady()) {
+        return false; // 기본 동작 허용
+      }
+
+      // 네비게이션 스택에 이전 화면이 있으면 기본 뒤로가기 동작
+      if (navigationRef.current.canGoBack()) {
+        navigationHandlers.handleBack();
+        return true; // 기본 동작 차단
+      }
+
+      // 루트 스크린에서 뒤로가기 시 Alert 확인 후 Splash로 이동
+      Alert.alert(
+        '앱 종료',
+        '앱을 종료하시겠습니까?',
+        [
+          {
+            text: '취소',
+            style: 'cancel',
+            onPress: () => {},
+          },
+          {
+            text: '종료',
+            style: 'destructive',
+            onPress: () => {
+              navigationHandlers.handleBackToSplash();
+            },
+          },
+        ],
+        { cancelable: true }
+      );
+
+      return true; // 기본 동작 차단
+    });
+
+    return () => backHandler.remove();
+  }, [navigationHandlers]);
 
   return (
     <NavigationContainer<RootStackParamList>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,45 @@
+/**
+ * React Navigation 타입 정의
+ * 각 화면의 route params를 정의합니다.
+ */
+
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+export type RootStackParamList = {
+  Splash: undefined;
+  Login: undefined;
+  EmailInput: undefined;
+  VerificationCode: undefined;
+  GoogleContinue: undefined;
+  KakaoContinue: undefined;
+  NaverContinue: undefined;
+  LoginComplete: undefined;
+  ServiceMain: undefined;
+  Dashboard: undefined;
+};
+
+export type RootStackScreenProps<Screen extends keyof RootStackParamList> =
+  NativeStackScreenProps<RootStackParamList, Screen>;
+
+/**
+ * ScreenType을 React Navigation route name으로 변환
+ */
+export type ScreenType = 'splash' | 'login' | 'email-input' | 'verification-code' | 'google-continue' | 'kakao-continue' | 'naver-continue' | 'login-complete' | 'service-main' | 'dashboard';
+
+export function screenTypeToRouteName(screenType: ScreenType): keyof RootStackParamList {
+  const mapping: Record<ScreenType, keyof RootStackParamList> = {
+    'splash': 'Splash',
+    'login': 'Login',
+    'email-input': 'EmailInput',
+    'verification-code': 'VerificationCode',
+    'google-continue': 'GoogleContinue',
+    'kakao-continue': 'KakaoContinue',
+    'naver-continue': 'NaverContinue',
+    'login-complete': 'LoginComplete',
+    'service-main': 'ServiceMain',
+    'dashboard': 'Dashboard',
+  };
+  
+  return mapping[screenType];
+}
+

--- a/src/utils/AuthEventHandler.ts
+++ b/src/utils/AuthEventHandler.ts
@@ -64,9 +64,9 @@ export function useAuthState(authManager: AuthManager | null): {
 } {
   const [authState, setAuthState] = useState<AuthState>(initialAuthState);
   const bridgeRef = useRef<ReactNativeBridge | null>(null);
-  const loginSuccessTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const autoRefreshTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const autoStopTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const loginSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // === 이벤트 핸들러 ===
   


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-196]


## 📝 작업 내용

화면 전환 방식을 조건부 렌더링에서 React Navigation으로 전환하고, 인증 핸들러 로직을 Custom Hook으로 분리하여 코드 구조를 개선했습니다.
1. React Navigation 도입
- 기존 : `if` 문으로 화면을 조건부 렌더링하는 방식은 확장성이 부족하고 뒤로가기, 히스토리 관리가 어려움
- 개선: 
  - 표준 네비게이션 라이브러리 사용으로 유지보수성 향상
  - 자동 뒤로가기 처리 및 네비게이션 히스토리 관리
  - 향후 딥링크, 화면 전환 애니메이션 등 확장 기능 추가 용이
2. 인증 핸들러 로직 분리
- 기존 : `App.tsx`에 핸들러 로직이 모두 포함되어 컴포넌트가 비대해짐
- 개선: 관심사 분리, 재사용성 증가, 컴포넌트 단순화

## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

- merge 후 작업 할 때 `npm install` 로 의존성 설치 후 작업해주세요!!


### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)

[WQ-196]: https://growgrammers.atlassian.net/browse/WQ-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ